### PR TITLE
Fix silent fatal errors in DOWNLOAD-ALL.bat

### DIFF
--- a/DOWNLOAD-ALL.bat
+++ b/DOWNLOAD-ALL.bat
@@ -65,13 +65,13 @@ REM ============================================================
 echo [2/5] Downloading MeshCore firmware (latest release)...
 echo.
 
-REM Try rocketgod's MeshCore firmware repo
-python "%TOOLKIT_DIR%download_github_release.py" rocketgod-git/meshcore ^
+REM Try official MeshCore firmware repo
+python "%TOOLKIT_DIR%download_github_release.py" meshcore-dev/meshcore ^
     --output "%TOOLKIT_DIR%meshcore-firmware" 2>nul
 if %ERRORLEVEL% neq 0 (
-    echo NOTE: Could not find rocketgod-git/meshcore.
+    echo NOTE: Could not find meshcore-dev/meshcore.
     echo Trying alternative MeshCore repos...
-    python "%TOOLKIT_DIR%download_github_release.py" meshcore/firmware ^
+    python "%TOOLKIT_DIR%download_github_release.py" aardzhanov/meshcore-firmware ^
         --output "%TOOLKIT_DIR%meshcore-firmware" 2>nul
 )
 echo.
@@ -139,9 +139,13 @@ echo.
 
 echo --- Meshtastic Firmware ---
 if exist "%TOOLKIT_DIR%meshtastic-firmware" (
-    dir /b "%TOOLKIT_DIR%meshtastic-firmware\*.zip" 2>nul | find /c /v "" > "%TEMP%\count.tmp"
+    dir /b "%TOOLKIT_DIR%meshtastic-firmware\*.zip" 2>nul | findstr /v ".gitkeep" | find /c /v "" > "%TEMP%\count.tmp"
     set /p MCOUNT=<"%TEMP%\count.tmp"
-    echo   Found !MCOUNT! firmware files
+    if "%MCOUNT%" == "0" (
+		echo	WARNING: No firmware downloaded
+	) else (
+		echo   Found !MCOUNT! firmware files
+	)
 ) else (
     echo   WARNING: No firmware downloaded
 )
@@ -149,9 +153,13 @@ if exist "%TOOLKIT_DIR%meshtastic-firmware" (
 echo.
 echo --- MeshCore Firmware ---
 if exist "%TOOLKIT_DIR%meshcore-firmware" (
-    dir /b "%TOOLKIT_DIR%meshcore-firmware\*" 2>nul | find /c /v "" > "%TEMP%\count.tmp"
+    dir /b "%TOOLKIT_DIR%meshcore-firmware\*" 2>nul | findstr /v ".gitkeep" | find /c /v "" > "%TEMP%\count.tmp"
     set /p CCOUNT=<"%TEMP%\count.tmp"
-    echo   Found !CCOUNT! firmware files
+    if "%CCOUNT%" == "0" (
+		echo	WARNING: No firmware downloaded
+	) else (
+		echo   Found !CCOUNT! firmware files
+	)
 ) else (
     echo   WARNING: No firmware downloaded
 )


### PR DESCRIPTION
## What does this PR do?
Fixes Issue #1 by:

- Changing the target repositories for MeshCore firmware downloads from ones that return `404` to the official `MeshCore-Dev/MeshCore` repository as the primary target and `aardzhanov`'s fork of the official repo as the secondary. 
    
    - Downloaded firmwares count for MeshCore increases from 0 to 238 (correct number of firmware variants for all supported Companion devices).

Fixes Issue #2 by:

-  Correcting an issue where a blank `.gitkeep` file (created by a download failure due to an unavailable repository) would be created inside the firmware download folder by using a pipe to `findstr` to filter files named `.gitkeep` out of the directory file count operation.
-  Correcting an issue where firmware download pass/fail condition was being determined entirely by existence of download folder (created by a download failure due to an unavailable repository) by adding a check to see if the reported number of downloaded firmwares for a given device type is `0`.
   
     - Script now either reports accurate number of downloaded firmwares to user, or reports `WARNING: No firmware downloaded` for *both* failures due to unavailable/non-existent GitHub repositories, and failures due to outages or blocking of the entire GitHub website.

## Device(s) tested
N/A

## Checklist
- [ ] Flash scripts work offline (no internet calls at flash time)
- [ ] README device table updated (if adding device support)
- [X] Error messages are clear and actionable
- [X] Tested on Windows (`.bat` scripts)
- [ ] Tested on Linux/macOS (`.sh` scripts) — optional but appreciated
